### PR TITLE
Add domain unit tests for scoring and date utilities

### DIFF
--- a/core/domain/src/test/java/com/jeremieguillot/core/domain/DateExtensionTest.kt
+++ b/core/domain/src/test/java/com/jeremieguillot/core/domain/DateExtensionTest.kt
@@ -1,0 +1,79 @@
+package com.jeremieguillot.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.Locale
+
+class DateExtensionTest {
+
+    @Test
+    fun `toZonedDateTime parses a utc date string`() {
+        val originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+
+        try {
+            val result = "2024-01-02 15:30:00".toZonedDateTime()
+
+            assertEquals(ZoneId.of("UTC"), result.zone)
+            assertEquals(2024, result.year)
+            assertEquals(1, result.monthValue)
+            assertEquals(2, result.dayOfMonth)
+            assertEquals(15, result.hour)
+            assertEquals(30, result.minute)
+        } finally {
+            Locale.setDefault(originalLocale)
+        }
+    }
+
+    @Test
+    fun `toFormattedString normalizes date to utc`() {
+        val originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+
+        try {
+            val parisDateTime = ZonedDateTime.of(
+                LocalDateTime.of(2024, 1, 2, 10, 30, 0),
+                ZoneId.of("Europe/Paris")
+            )
+
+            val formatted = parisDateTime.toFormattedString()
+
+            assertEquals("2024-01-02 09:30:00", formatted)
+        } finally {
+            Locale.setDefault(originalLocale)
+        }
+    }
+
+    @Test
+    fun `toLocalizedDateString returns formatted date for current locale`() {
+        val originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+
+        try {
+            val dateTime = ZonedDateTime.of(LocalDateTime.of(2024, 1, 2, 0, 0), ZoneId.of("UTC"))
+
+            val localized = dateTime.toLocalizedDateString()
+
+            assertEquals("January 2, 2024", localized)
+        } finally {
+            Locale.setDefault(originalLocale)
+        }
+    }
+
+    @Test
+    fun `toUtc converts any zone to utc while preserving instant`() {
+        val parisDateTime = ZonedDateTime.of(
+            LocalDateTime.of(2024, 1, 2, 10, 30),
+            ZoneId.of("Europe/Paris")
+        )
+
+        val utcDateTime = parisDateTime.toUtc()
+
+        assertEquals(ZoneId.of("UTC"), utcDateTime.zone)
+        assertTrue(parisDateTime.toInstant() == utcDateTime.toInstant())
+    }
+}

--- a/core/domain/src/test/java/com/jeremieguillot/core/domain/ScoreCalculatorTest.kt
+++ b/core/domain/src/test/java/com/jeremieguillot/core/domain/ScoreCalculatorTest.kt
@@ -1,0 +1,34 @@
+package com.jeremieguillot.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScoreCalculatorTest {
+
+    @Test
+    fun `calculateScore returns zero when nothing is provided`() {
+        val calculator = ScoreCalculator(numberOfPhotos = 0, numberOfParticipants = 0, isCleaningDone = false)
+
+        val score = calculator.calculateScore()
+
+        assertEquals(0, score)
+    }
+
+    @Test
+    fun `calculateScore adds photo and participant points`() {
+        val calculator = ScoreCalculator(numberOfPhotos = 3, numberOfParticipants = 2, isCleaningDone = false)
+
+        val score = calculator.calculateScore()
+
+        assertEquals(40, score)
+    }
+
+    @Test
+    fun `calculateScore adds cleaning bonus when cleaning is done`() {
+        val calculator = ScoreCalculator(numberOfPhotos = 1, numberOfParticipants = 0, isCleaningDone = true)
+
+        val score = calculator.calculateScore()
+
+        assertEquals(60, score)
+    }
+}

--- a/core/domain/src/test/java/com/jeremieguillot/core/domain/util/ResultExtensionsTest.kt
+++ b/core/domain/src/test/java/com/jeremieguillot/core/domain/util/ResultExtensionsTest.kt
@@ -1,0 +1,53 @@
+package com.jeremieguillot.core.domain.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ResultExtensionsTest {
+
+    private object FakeError : Error
+
+    @Test
+    fun `map transforms success value`() {
+        val initial: Result<Int, FakeError> = Result.Success(2)
+
+        val mapped = initial.map { it * 3 }
+
+        assertTrue(mapped is Result.Success)
+        assertEquals(6, (mapped as Result.Success).data)
+    }
+
+    @Test
+    fun `map keeps error untouched`() {
+        val errorInstance = FakeError
+        val initial: Result<Int, FakeError> = Result.Error(errorInstance)
+
+        val mapped = initial.map { it * 3 }
+
+        assertTrue(mapped is Result.Error)
+        assertSame(errorInstance, (mapped as Result.Error).error)
+    }
+
+    @Test
+    fun `asEmptyDataResult wraps success into unit`() {
+        val initial: Result<String, FakeError> = Result.Success("value")
+
+        val emptyResult = initial.asEmptyDataResult()
+
+        assertTrue(emptyResult is Result.Success)
+        assertEquals(Unit, (emptyResult as Result.Success).data)
+    }
+
+    @Test
+    fun `asEmptyDataResult propagates error`() {
+        val errorInstance = FakeError
+        val initial: Result<String, FakeError> = Result.Error(errorInstance)
+
+        val emptyResult = initial.asEmptyDataResult()
+
+        assertTrue(emptyResult is Result.Error)
+        assertSame(errorInstance, (emptyResult as Result.Error).error)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 #org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
## Summary
- add unit tests for ScoreCalculator covering photo, participant and cleaning scenarios
- cover date extension conversions to UTC, formatted output and localization
- verify Result.map and asEmptyDataResult behaviour and adjust Gradle JVM args for Java 11+